### PR TITLE
Removed unwanted top and bottom padding from ListView

### DIFF
--- a/lib/src/chips_input.dart
+++ b/lib/src/chips_input.dart
@@ -137,6 +137,7 @@ class ChipsInputState<T> extends State<ChipsInput<T>>
                     elevation: 4.0,
                     child: ListView.builder(
                       shrinkWrap: true,
+                      padding: EdgeInsets.zero,
                       itemCount: snapshot.data?.length ?? 0,
                       itemBuilder: (BuildContext context, int index) {
                         return widget.suggestionBuilder(


### PR DESCRIPTION
From the ListView documentation:

> By default, ListView will automatically pad the list's scrollable extremities to avoid partial 
> obstructions indicated by MediaQuery's padding. To avoid this behavior, override with a zero
> padding property.

This is unexpected behavior when used in an overlay. It adds unwanted padding making the list bigger than necessary. The result is this:

<img width="295" alt="Skjermbilde 2019-06-09 kl  23 27 29" src="https://user-images.githubusercontent.com/866528/59164533-83e2e980-8b0e-11e9-9abc-3a56e27422d7.png">

Adding `padding: EdgeInsets.zero` gives the expected behavior:
<img width="283" alt="Skjermbilde 2019-06-09 kl  23 29 49" src="https://user-images.githubusercontent.com/866528/59164542-c0164a00-8b0e-11e9-9ca6-7281372ef25a.png">

See also [How to remove automatic SafeArea from ListView?](https://stackoverflow.com/questions/52105557/how-to-remove-automatic-safearea-from-listview)
