### PR TITLE
Implementing connectionClosed method

### DIFF
--- a/lib/src/chips_input.dart
+++ b/lib/src/chips_input.dart
@@ -353,6 +353,11 @@ class ChipsInputState<T> extends State<ChipsInput<T>>
   void updateFloatingCursor(RawFloatingCursorPoint point) {
     print(point);
   }
+
+  @override
+  void connectionClosed() {
+    print('TextInputClient.connectionCLosed()');
+  }
 }
 
 class AlwaysDisabledFocusNode extends FocusNode {


### PR DESCRIPTION
TextInputClient now includes a new connectionClosed method to cleanup its connection and finalize editing.

This is a new method that is now preventing new flutter projects to build when using flutter_form_builder on the latest version of flutter.