### PR TITLE
Added the `showAutocorrectionPromptRect` method

### DIFF
--- a/lib/src/chips_input.dart
+++ b/lib/src/chips_input.dart
@@ -378,6 +378,10 @@ class ChipsInputState<T> extends State<ChipsInput<T>>
 
   @override
   TextEditingValue get currentTextEditingValue => _value;
+
+  @override
+  void showAutocorrectionPromptRect(int start, int end) {
+  }
 }
 
 class AlwaysDisabledFocusNode extends FocusNode {


### PR DESCRIPTION
The definition of `TextInputClient` is changed on the Flutter master branch. It has a new method   `showAutocorrectionPromptRect` that requests client display a prompt rectangle for the given text range to indicate the range of text that will be changed by a pending autocorrection.

Added the `showAutocorrectionPromptRect` method to make `flutter_chips_input` compatible with the latest Flutter version.