### PR TITLE
Unicode character disappear bug

### DIFF
--- a/lib/src/chips_input.dart
+++ b/lib/src/chips_input.dart
@@ -309,8 +309,6 @@ class ChipsInputState<T> extends State<ChipsInput<T>>
           _enteredTexts.remove(removedChip);
         }
         _updateTextInputState(putText: putText);
-      } else {
-        _updateTextInputState();
       }
       _onSearchChanged(_value.normalCharactersText);
     }


### PR DESCRIPTION
Since https://github.com/danvick/flutter_chips_input/commit/d507790 commit, I can't input Unicode-characters.

- Expected
  + (Korean) `ㅌ` → Press `ㅔ` → `테`
  + (Japanese Romaji) `こども` → Press `<Space>` → Press `<Enter>` → `子供`
- Actually
  + (Korean) `ㅌ` → Press `ㅔ` → `(Empty)` 
  + (Japanese Romaji) `こども` → Press `<Space>` → Press `<Enter>` → `(Empty)` 

I tested in Korean, Japanese. Maybe works with Chinese too.
