### PR TITLE
Optionally show initial suggestions

### DIFF
--- a/lib/src/chips_input.dart
+++ b/lib/src/chips_input.dart
@@ -27,31 +27,32 @@ extension on TextEditingValue {
 }
 
 class ChipsInput<T> extends StatefulWidget {
-  const ChipsInput({
-    Key key,
-    this.initialValue = const [],
-    this.decoration = const InputDecoration(),
-    this.enabled = true,
-    @required this.chipBuilder,
-    @required this.suggestionBuilder,
-    @required this.findSuggestions,
-    @required this.onChanged,
-    this.onChipTapped,
-    this.maxChips,
-    this.textStyle,
-    this.suggestionsBoxMaxHeight,
-    this.inputType = TextInputType.text,
-    this.textOverflow = TextOverflow.clip,
-    this.obscureText = false,
-    this.autocorrect = true,
-    this.actionLabel,
-    this.inputAction = TextInputAction.done,
-    this.keyboardAppearance = Brightness.light,
-    this.textCapitalization = TextCapitalization.none,
-    this.autofocus = false,
-    this.allowChipEditing = false,
-    this.focusNode,
-  })  : assert(maxChips == null || initialValue.length <= maxChips),
+  const ChipsInput(
+      {Key key,
+      this.initialValue = const [],
+      this.decoration = const InputDecoration(),
+      this.enabled = true,
+      @required this.chipBuilder,
+      @required this.suggestionBuilder,
+      @required this.findSuggestions,
+      @required this.onChanged,
+      this.onChipTapped,
+      this.maxChips,
+      this.textStyle,
+      this.suggestionsBoxMaxHeight,
+      this.inputType = TextInputType.text,
+      this.textOverflow = TextOverflow.clip,
+      this.obscureText = false,
+      this.autocorrect = true,
+      this.actionLabel,
+      this.inputAction = TextInputAction.done,
+      this.keyboardAppearance = Brightness.light,
+      this.textCapitalization = TextCapitalization.none,
+      this.autofocus = false,
+      this.allowChipEditing = false,
+      this.focusNode,
+      this.initialSuggestions})
+      : assert(maxChips == null || initialValue.length <= maxChips),
         super(key: key);
 
   final InputDecoration decoration;
@@ -76,6 +77,7 @@ class ChipsInput<T> extends StatefulWidget {
   final bool autofocus;
   final bool allowChipEditing;
   final FocusNode focusNode;
+  final List<dynamic> initialSuggestions;
 
   // final Color cursorColor;
 
@@ -123,6 +125,9 @@ class ChipsInputState<T> extends State<ChipsInput<T>>
   void initState() {
     super.initState();
     _chips.addAll(widget.initialValue);
+    _suggestions = widget.initialSuggestions
+        ?.where((r) => !_chips.contains(r))
+        ?.toList(growable: false);
     // _focusAttachment = _focusNode.attach(context);
     _suggestionsBoxController = SuggestionsBoxController(context);
 
@@ -160,7 +165,7 @@ class ChipsInputState<T> extends State<ChipsInput<T>>
   void _handleFocusChanged() {
     if (_focusNode.hasFocus) {
       _openInputConnection();
-      /* _suggestionsBoxController.open(); */
+      _suggestionsBoxController.open();
     } else {
       _closeInputConnectionIfNeeded();
       _suggestionsBoxController.close();
@@ -193,6 +198,7 @@ class ChipsInputState<T> extends State<ChipsInput<T>>
 
         return StreamBuilder<List<T>>(
           stream: _suggestionsStreamController.stream,
+          initialData: _suggestions,
           builder: (context, snapshot) {
             if (snapshot.hasData && snapshot.data.isNotEmpty) {
               var suggestionsListView = Material(

--- a/lib/src/chips_input.dart
+++ b/lib/src/chips_input.dart
@@ -27,32 +27,32 @@ extension on TextEditingValue {
 }
 
 class ChipsInput<T> extends StatefulWidget {
-  const ChipsInput(
-      {Key key,
-      this.initialValue = const [],
-      this.decoration = const InputDecoration(),
-      this.enabled = true,
-      @required this.chipBuilder,
-      @required this.suggestionBuilder,
-      @required this.findSuggestions,
-      @required this.onChanged,
-      this.onChipTapped,
-      this.maxChips,
-      this.textStyle,
-      this.suggestionsBoxMaxHeight,
-      this.inputType = TextInputType.text,
-      this.textOverflow = TextOverflow.clip,
-      this.obscureText = false,
-      this.autocorrect = true,
-      this.actionLabel,
-      this.inputAction = TextInputAction.done,
-      this.keyboardAppearance = Brightness.light,
-      this.textCapitalization = TextCapitalization.none,
-      this.autofocus = false,
-      this.allowChipEditing = false,
-      this.focusNode,
-      this.initialSuggestions})
-      : assert(maxChips == null || initialValue.length <= maxChips),
+  const ChipsInput({
+    Key key,
+    this.initialValue = const [],
+    this.decoration = const InputDecoration(),
+    this.enabled = true,
+    @required this.chipBuilder,
+    @required this.suggestionBuilder,
+    @required this.findSuggestions,
+    @required this.onChanged,
+    this.onChipTapped,
+    this.maxChips,
+    this.textStyle,
+    this.suggestionsBoxMaxHeight,
+    this.inputType = TextInputType.text,
+    this.textOverflow = TextOverflow.clip,
+    this.obscureText = false,
+    this.autocorrect = true,
+    this.actionLabel,
+    this.inputAction = TextInputAction.done,
+    this.keyboardAppearance = Brightness.light,
+    this.textCapitalization = TextCapitalization.none,
+    this.autofocus = false,
+    this.allowChipEditing = false,
+    this.focusNode,
+    this.initialSuggestions,
+  })  : assert(maxChips == null || initialValue.length <= maxChips),
         super(key: key);
 
   final InputDecoration decoration;
@@ -77,7 +77,7 @@ class ChipsInput<T> extends StatefulWidget {
   final bool autofocus;
   final bool allowChipEditing;
   final FocusNode focusNode;
-  final List<dynamic> initialSuggestions;
+  final List<T> initialSuggestions;
 
   // final Color cursorColor;
 

--- a/lib/src/chips_input.dart
+++ b/lib/src/chips_input.dart
@@ -160,7 +160,7 @@ class ChipsInputState<T> extends State<ChipsInput<T>>
   void _handleFocusChanged() {
     if (_focusNode.hasFocus) {
       _openInputConnection();
-      _suggestionsBoxController.open();
+      /* _suggestionsBoxController.open(); */
     } else {
       _closeInputConnectionIfNeeded();
       _suggestionsBoxController.close();


### PR DESCRIPTION
Hey danvick, I made this PR to add a simple feature: be able to show the suggestions box as soon as the field gains focus, without typing in the keyboard.
I found myself in an use case where it would be useful to have the ChipsInput work sort of like a dropdown input, but still being able to receive multiple values. I figured this might be a common use case to other people too, so I made a PR.

Let me know if you have any feedback and thanks for the awesome work in the package!

![ezgif-1-afa5eb1a3838](https://user-images.githubusercontent.com/48812611/101947838-da335b80-3bcf-11eb-8814-d38d9665c0b7.gif)


