### PR TITLE
Add option to don't show keyboard when input is focused

### DIFF
--- a/lib/src/chips_input.dart
+++ b/lib/src/chips_input.dart
@@ -52,6 +52,7 @@ class ChipsInput<T> extends StatefulWidget {
     this.allowChipEditing = false,
     this.focusNode,
     this.initialSuggestions,
+    this.showKeyboard = true,
   })  : assert(maxChips == null || initialValue.length <= maxChips),
         super(key: key);
 
@@ -78,6 +79,7 @@ class ChipsInput<T> extends StatefulWidget {
   final bool allowChipEditing;
   final FocusNode focusNode;
   final List<T> initialSuggestions;
+  final bool showKeyboard;
 
   // final Color cursorColor;
 
@@ -164,8 +166,9 @@ class ChipsInputState<T> extends State<ChipsInput<T>>
 
   void _handleFocusChanged() {
     if (_focusNode.hasFocus) {
-      _openInputConnection();
-      _suggestionsBoxController.open();
+      if (widget.showKeyboard) {
+        _openInputConnection();
+      }
     } else {
       _closeInputConnectionIfNeeded();
       _suggestionsBoxController.close();
@@ -262,6 +265,9 @@ class ChipsInputState<T> extends State<ChipsInput<T>>
       _suggestionsBoxController.close();
     }
     widget.onChanged(_chips.toList(growable: false));
+    if (!widget.showKeyboard) {
+      _focusNode.unfocus();
+    }
   }
 
   void deleteChip(T data) {


### PR DESCRIPTION
Hey guys, I've made this PR so we are able to choose if the keyboard should appear or not.
I noticed that in some use cases we have few options to choose from and the device's keyboard takes up to much of the screen, making it hard to use the suggestions box properly.
Please let me know if you have any feedback, thanks!