### PR TITLE
Fix iOS Keyboard Entry Jitter

### DIFF
--- a/lib/src/chips_input.dart
+++ b/lib/src/chips_input.dart
@@ -364,6 +364,7 @@ class ChipsInputState<T> extends State<ChipsInput<T>>
     });
     _textInputConnection ??= TextInput.attach(this, textInputConfiguration);
     _textInputConnection?.setEditingState(_value);
+    _textInputConnection?.show();
   }
 
   @override


### PR DESCRIPTION
In order to fix the bug preventing continuous typing in iOS with Flutter 2.5.x, added an explicit call to `TextInputConnection.show()` each time it's reinitialized or else users have to re-tap/focus the input after each character (which also causes the keyboard to disappear after each character typed).

fixes #97