### PR TITLE
Add a Null-Check before insert the overlayEntry inside SuggestionBoxController

### DIFF
--- a/lib/src/suggestions_box_controller.dart
+++ b/lib/src/suggestions_box_controller.dart
@@ -14,7 +14,7 @@ class SuggestionsBoxController {
   void open() {
     if (_isOpened) return;
     assert(overlayEntry != null);
-    Overlay.of(context)!.insert(overlayEntry!);
+    Overlay.of(context)?.insert(overlayEntry!);
     _isOpened = true;
   }
 


### PR DESCRIPTION
Overlay.of(context) can be null, therefore a !-Operator is not appropriate here. Right now this code can result in a _CastError, which results in immediately closing of the keyboard when trying to open it.